### PR TITLE
add directives key to helmet contentSecurityPolicy

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -66,13 +66,15 @@ var styleSources = ["'self'", "'unsafe-inline'", "ajax.googleapis.com"];
 var connectSources = ["'self'"];
 
 server.use(helmet.contentSecurityPolicy({
+  directives: {
     defaultSrc: ["'self'"],
     scriptSrc: scriptSources,
     styleSrc: styleSources,
     connectSrc: connectSources,
-    reportOnly: false,
-    setAllHeaders: false,
-    safari5: false
+  },
+  reportOnly: false,
+  setAllHeaders: false,
+  safari5: false
 }));
 
 server.use(methodOverride());


### PR DESCRIPTION
- src/server/server.js
moved some existing properties into the directives key

I did this because I was getting a bug saying the directives key was required and it looked like those properties belonged in the directives key.